### PR TITLE
protego 0.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,14 @@ about:
   home: https://github.com/scrapy/protego
   license: BSD 3-Clauses
   license_file: LICENSE
+  license_family: BSD
   summary: A pure-Python robots.txt parser with support for modern conventions
+  description: |
+    A pure-Python robots.txt parser with support for modern conventions
+    like the one defined by Google.
+  doc_url: https://github.com/scrapy/protego
+  dev_url: https://github.com/scrapy/protego
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "Protego" %}
-{% set version = "0.1.16" %}
+{% set version = "0.4.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name | lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a682771bc7b51b2ff41466460896c1a5a653f9a1e71639ef365a72e66d8734b4
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|lower }}-{{ version }}.tar.gz
+  sha256: 93a5e662b61399a0e1f208a324f2c6ea95b23ee39e6cbf2c96246da4a656c2f6
 
 build:
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . -vv"
   number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -20,7 +20,6 @@ requirements:
     - pip
   run:
     - python
-    - six
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,16 +24,20 @@ requirements:
     - python
 
 test:
+  imports:
+    - protego
   requires:
+    - pip
     - pytest
   source_files:
     - tests
   commands:
+    - pip check
     - pytest tests
 
 about:
   home: https://github.com/scrapy/protego
-  license: BSD 3-Clauses
+  license: BSD-3-Clause
   license_file: LICENSE
   license_family: BSD
   summary: A pure-Python robots.txt parser with support for modern conventions


### PR DESCRIPTION
protego 0.4.0

**Destination channel:** Defaults

### Links

- [PKG-7832]
- dev_url:        https://github.com/scrapy/protego/tree/0.4.0
- conda_forge:    https://github.com/conda-forge/protego-feedstock
- pypi:           https://pypi.org/project/protego/0.4.0
- pypi inspector: https://inspector.pypi.io/project/protego/0.4.0

### Explanation of changes:

- new version number
- removed dep, no longer needed

[PKG-7832]: https://anaconda.atlassian.net/browse/PKG-7832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ